### PR TITLE
Fix registration flow and tighten security

### DIFF
--- a/src/main/java/com/treasurehunt/config/SecurityConfig.java
+++ b/src/main/java/com/treasurehunt/config/SecurityConfig.java
@@ -30,6 +30,15 @@ public class SecurityConfig {
     @Value("${app.security.admin.password}")
     private String adminPassword;
 
+    private static final String CSP_POLICY =
+            "default-src 'self'; " +
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.youtube.com; " +
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; " +
+            "img-src 'self' data: https:; " +
+            "font-src 'self' https://cdnjs.cloudflare.com; " +
+            "frame-src 'self' https://www.youtube.com https://youtube.com; " +
+            "media-src 'self' https://www.youtube.com https://youtube.com;";
+
     /**
      * Configure HTTP security
      * @param http HttpSecurity configuration
@@ -60,8 +69,8 @@ public class SecurityConfig {
                 .requestMatchers("/admin/images/**").hasRole("ADMIN")
                 .requestMatchers("/secure/files/documents/**").hasRole("ADMIN") // Secure document access
 
-                // All other requests are public by default (changed from authenticated)
-                .anyRequest().permitAll()
+                // All other requests require authentication
+                .anyRequest().authenticated()
             )
             .formLogin(form -> form
                 .loginPage("/admin/login")
@@ -104,9 +113,7 @@ public class SecurityConfig {
                     .maxAgeInSeconds(31536000)
                     .includeSubDomains(true)
                 )
-                .contentSecurityPolicy(csp -> csp
-                    .policyDirectives("default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.youtube.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; img-src 'self' data: https:; font-src 'self' https://cdnjs.cloudflare.com; frame-src 'self' https://www.youtube.com https://youtube.com; media-src 'self' https://www.youtube.com https://youtube.com https:")
-                )
+                .contentSecurityPolicy(csp -> csp.policyDirectives(CSP_POLICY))
             );
 
         return http.build();

--- a/src/main/java/com/treasurehunt/controller/RegistrationController.java
+++ b/src/main/java/com/treasurehunt/controller/RegistrationController.java
@@ -236,19 +236,23 @@ public class RegistrationController {
         // File size validation is handled in FileStorageService with configurable limits
         // This ensures consistent validation across the application
 
-        // Temporarily disable file type validation for testing email functionality
-        /*
-        // Validate file types (basic check)
+        // Validate file types
         String photoContentType = photoFile.getContentType();
-        if (photoContentType == null || !photoContentType.startsWith("image/")) {
+        if (photoContentType == null || !photoContentType.toLowerCase().startsWith("image/")) {
             return "Photo must be an image file (JPG, JPEG, PNG)";
         }
 
-        String medicalContentType = medicalFile.getContentType();
-        if (medicalContentType == null || !"application/pdf".equals(medicalContentType)) {
-            return "Medical certificate must be a PDF file";
+        String idContentType = idFile.getContentType();
+        if (idContentType == null || !(idContentType.equalsIgnoreCase("application/pdf") || idContentType.toLowerCase().startsWith("image/"))) {
+            return "ID document must be an image or PDF file";
         }
-        */
+
+        if (medicalConsentGiven == null || !medicalConsentGiven) {
+            String medicalContentType = medicalFile.getContentType();
+            if (medicalContentType == null || !"application/pdf".equalsIgnoreCase(medicalContentType)) {
+                return "Medical certificate must be a PDF file";
+            }
+        }
 
         return null; // All validations passed
     }

--- a/src/main/java/com/treasurehunt/dto/TeamMemberDTO.java
+++ b/src/main/java/com/treasurehunt/dto/TeamMemberDTO.java
@@ -9,8 +9,8 @@ public class TeamMemberDTO {
     private String fullName;
 
     @NotNull(message = "Age is required")
-    @Min(value = 16, message = "Minimum age is 16")
-    @Max(value = 100, message = "Maximum age is 100")
+    @Min(value = 18, message = "Minimum age is 18")
+    @Max(value = 65, message = "Maximum age is 65")
     private Integer age;
 
     @NotBlank(message = "Gender is required")

--- a/src/main/java/com/treasurehunt/service/RegistrationService.java
+++ b/src/main/java/com/treasurehunt/service/RegistrationService.java
@@ -103,6 +103,13 @@ public class RegistrationService {
         // Set plan and save registration
         registration.setPlan(plan);
         registration.setStatus(UserRegistration.RegistrationStatus.PENDING);
+
+        // Generate application ID before persisting
+        String applicationId = registration.isTeamRegistration()
+                ? applicationIdService.generateTeamApplicationId(plan.getId())
+                : applicationIdService.generateIndividualApplicationId(plan.getId());
+        registration.setApplicationId(applicationId);
+
         UserRegistration savedRegistration = registrationRepository.save(registration);
 
         try {

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -7,6 +7,9 @@
 window.currentStep = 1;
 window.selectedPlan = null;
 
+let formListenersInitialized = false;
+let progressListenersInitialized = false;
+
 // Robust step navigation functions
 window.showStepRobust = function(step) {
     // Hide all steps
@@ -1281,6 +1284,9 @@ const updateTeamProgress = debounce(function() {
  * Attach event listeners for progress tracking
  */
 function attachProgressEventListeners() {
+    if (progressListenersInitialized) return;
+    progressListenersInitialized = true;
+
     const form = document.getElementById('registrationForm');
     if (!form) {
         console.log('❌ Registration form not found for progress listeners');
@@ -1291,16 +1297,9 @@ function attachProgressEventListeners() {
     console.log(`📝 Attaching progress listeners to ${inputs.length} form inputs`);
 
     inputs.forEach((input, index) => {
-        // Remove existing listeners to avoid duplicates
-        input.removeEventListener('input', handleProgressUpdate);
-        input.removeEventListener('change', handleProgressUpdate);
-        input.removeEventListener('blur', handleProgressUpdate);
-
-        // Add new listeners
         input.addEventListener('input', handleProgressUpdate);
         input.addEventListener('change', handleProgressUpdate);
         input.addEventListener('blur', handleProgressUpdate);
-
         console.log(`✅ Listeners attached to ${input.id || input.name || 'unnamed field'}`);
     });
 }
@@ -1317,6 +1316,9 @@ function handleProgressUpdate(event) {
  * Setup form event listeners
  */
 function setupFormEventListeners() {
+    if (formListenersInitialized) return;
+    formListenersInitialized = true;
+
     const form = document.getElementById('registrationForm');
     if (form) {
         form.addEventListener('submit', handleFormSubmit);
@@ -1523,6 +1525,7 @@ function toggleMedicalCertificateUpload(consentGiven) {
 
         if (fileInput) {
             fileInput.required = false;
+            fileInput.disabled = true;
         }
 
         console.log('✅ Medical certificate upload disabled (consent given)');
@@ -1548,6 +1551,7 @@ function toggleMedicalCertificateUpload(consentGiven) {
 
         if (fileInput) {
             fileInput.required = true;
+            fileInput.disabled = false;
         }
 
         console.log('✅ Medical certificate upload enabled (consent not given)');


### PR DESCRIPTION
## Summary
- generate application IDs in TH-TYPE-PPPPSS format and persist them on registrations
- align document checks with medical consent and enable file-type validation
- prevent duplicate frontend listeners and lock down security config

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6893be61aa908323b2b12e283026ed92